### PR TITLE
Fix lockable attribute problem

### DIFF
--- a/git/attribs.go
+++ b/git/attribs.go
@@ -162,6 +162,12 @@ func AttrPathsFromReader(mp *gitattr.MacroProcessor, fpath, workingDir string, r
 
 		pattern := line.Pattern().String()
 		if len(reldir) > 0 {
+			if len(pattern) > 0 {
+				slashCount := strings.Count(pattern, "/")
+				if slashCount == 0 || (slashCount == 1 && pattern[len(pattern)-1:] == "/") {
+					pattern = path.Join("**", pattern)
+				}
+			}
 			pattern = path.Join(reldir, pattern)
 		}
 


### PR DESCRIPTION
## Problem
`lockable` attribute in _.gitattributes_ located on sub-directory could not be enabled.

## Steps for reproduce
See [test repo](https://github.com/exceed-alae/git-lfs-test-for-lockable-problem/).

## Detail of fix
Add `**/` to internal path pattern in .gitattributes located on sub-directory if path has no slash or only tail slash.